### PR TITLE
feat: getPosition/usePosition 

### DIFF
--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -1,32 +1,23 @@
 import {
+	type Chain,
 	arbitrum,
+	arbitrumSepolia,
 	avalanche,
 	base,
+	baseSepolia,
 	blast,
 	bsc,
 	celo,
 	mainnet,
 	optimism,
 	polygon,
+	sepolia,
+	unichain,
+	unichainSepolia,
 	worldchain,
 	zksync,
 	zora,
 } from "wagmi/chains";
-// uniswap supported chains
-/* 
-Ethereum
-Arbitrum
-Optimism
-Polygon
-Base
-BNB
-Avalanche C-Chain
-CELO
-Blast
-ZKsync
-Zora
-WorldChain
-*/
 
 export const supportedChains = [
 	arbitrum,
@@ -40,11 +31,21 @@ export const supportedChains = [
 	zksync,
 	zora,
 	worldchain,
+	unichain,
 	mainnet,
 ] as const;
 
-export const getChainById = (chainId: number) => {
-	const chain = supportedChains.find((chain) => chain.id === chainId);
+export const testChains = [
+	unichainSepolia,
+	sepolia,
+	baseSepolia,
+	arbitrumSepolia,
+] as const;
+
+export const getChainById = (chainId: number): Chain => {
+	const chain = [...supportedChains, ...testChains].find(
+		(chain) => chain.id === chainId,
+	);
 	if (!chain) {
 		throw new Error(`Chain with id ${chainId} not found`);
 	}

--- a/src/helpers/positions.ts
+++ b/src/helpers/positions.ts
@@ -1,0 +1,52 @@
+/**
+ * Decodes a signed 24-bit integer (`int24`) from a packed `bigint` at a given bit offset.
+ *
+ * @param info - The packed `bigint` containing the encoded data.
+ * @param shift - The bit offset where the `int24` value begins.
+ * @returns The decoded signed 24-bit integer as a number.
+ *
+ * @example
+ * ```ts
+ * const tickLower = decodeInt24FromInfo(info, 8);
+ * const tickUpper = decodeInt24FromInfo(info, 32);
+ * ```
+ */
+export function decodeInt24FromInfo(info: bigint, shift: number): number {
+	const raw = (info >> BigInt(shift)) & 0xffffffn; // Extract 24 bits
+	return raw >= 0x800000n ? Number(raw - 0x1000000n) : Number(raw); // Handle sign bit
+}
+
+/**
+ * Decodes position metadata packed in a `uint256` returned by Uniswap V4's `getPoolAndPositionInfo`.
+ * The structure of the encoded info is:
+ * - bits 0–7: `hasSubscriber` flag (boolean in practice, stored as `uint8`)
+ * - bits 8–31: `tickLower` (int24)
+ * - bits 32–55: `tickUpper` (int24)
+ * - bits 56–255: `poolId` (bytes25, used as bytes32 with padding)
+ *
+ * @param info - The packed position info as a `bigint`
+ * @returns An object containing:
+ *  - `hasSubscriber`: number (usually 0 or 1)
+ *  - `tickLower`: number (int24)
+ *  - `tickUpper`: number (int24)
+ *  - `poolId`: bigint (25-byte identifier of the pool)
+ *
+ * @example
+ * ```ts
+ * const decoded = decodePositionInfo(info);
+ * console.log(decoded.tickLower, decoded.poolId.toString(16));
+ * ```
+ */
+export function decodePositionInfo(info: bigint): {
+	hasSubscriber: number;
+	tickLower: number;
+	tickUpper: number;
+	poolId: bigint;
+} {
+	return {
+		hasSubscriber: Number(info & 0xffn),
+		tickLower: decodeInt24FromInfo(info, 8),
+		tickUpper: decodeInt24FromInfo(info, 32),
+		poolId: info >> 56n,
+	};
+}

--- a/src/hooks/useGetPosition.ts
+++ b/src/hooks/useGetPosition.ts
@@ -1,0 +1,47 @@
+import type {
+	PositionResult,
+	UseGetPositionOptions,
+} from "@/types/hooks/useGetPosition";
+import { getPosition } from "@/utils/getPosition";
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * React hook for fetching Uniswap V4 position data using React Query.
+ * Handles caching, loading states, and error handling automatically.
+ *
+ * @param options - Configuration options for the hook
+ * @returns Query result containing position data, loading state, error state, and refetch function
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, error, refetch } = useGetPosition({
+ *   tokenId: 123,
+ *   chainId: 1,
+ *   queryOptions: {
+ *     enabled: true,
+ *     staleTime: 30000,
+ *     gcTime: 300000,
+ *     retry: 3,
+ *     onSuccess: (data) => console.log('Position data received:', data)
+ *   }
+ * });
+ * ```
+ */
+export function useGetPosition({
+	tokenId,
+	chainId,
+	queryOptions = {},
+}: UseGetPositionOptions = {}) {
+	if (!tokenId) throw new Error("No tokenId provided");
+
+	return useQuery<
+		PositionResult | undefined,
+		Error,
+		PositionResult | undefined,
+		unknown[]
+	>({
+		queryKey: ["position", tokenId, chainId],
+		queryFn: () => getPosition(tokenId, chainId),
+		...queryOptions,
+	});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from "@/core/uniDevKitV4Factory";
 
 // Hooks
 export * from "@/hooks/useGetPool";
+export * from "@/hooks/useGetPosition";
 export * from "@/hooks/useGetQuote";
 
 // Utils

--- a/src/test/hooks/useGetPosition.test.ts
+++ b/src/test/hooks/useGetPosition.test.ts
@@ -1,0 +1,158 @@
+import { useGetPosition } from "@/hooks/useGetPosition";
+import { getPosition } from "@/utils/getPosition";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { Token } from "@uniswap/sdk-core";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock getPosition
+vi.mock("@/utils/getPosition", () => ({
+	getPosition: vi.fn(),
+}));
+
+describe("useGetPosition", () => {
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		});
+		vi.resetAllMocks();
+	});
+
+	const wrapper = ({ children }: { children: React.ReactNode }) =>
+		_jsx(QueryClientProvider, { client: queryClient, children });
+
+	it("should fetch position data successfully", async () => {
+		const mockPosition = {
+			token0: new Token(
+				1,
+				"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+				6,
+				"USDC",
+				"USD Coin",
+			),
+			token1: new Token(
+				1,
+				"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+				18,
+				"WETH",
+				"Wrapped Ether",
+			),
+			amounts: {
+				amount0: "1000000",
+				amount1: "1000000000000000000",
+			},
+			tickLower: -100,
+			tickUpper: 100,
+			liquidity: BigInt("1000000000000000000"),
+			poolId: "0x1234567890123456789012345678901234567890",
+		};
+
+		(getPosition as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+			mockPosition,
+		);
+
+		const { result } = renderHook(
+			() =>
+				useGetPosition({
+					tokenId: "123",
+					chainId: 1,
+				}),
+			{ wrapper },
+		);
+
+		expect(result.current.isLoading).toBe(true);
+		expect(result.current.data).toBeUndefined();
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		expect(result.current.data).toEqual(mockPosition);
+		expect(getPosition).toHaveBeenCalledWith("123", 1);
+	});
+
+	it("should handle errors", async () => {
+		const error = new Error("Failed to fetch position");
+		(getPosition as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+			error,
+		);
+
+		const { result } = renderHook(
+			() =>
+				useGetPosition({
+					tokenId: "123",
+					chainId: 1,
+				}),
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		expect(result.current.error).toEqual(error);
+	});
+
+	it("should throw error if no tokenId provided", () => {
+		expect(() => {
+			renderHook(() => useGetPosition(), { wrapper });
+		}).toThrow("No tokenId provided");
+	});
+
+	it("should handle custom query options", async () => {
+		const mockPosition = {
+			token0: new Token(
+				1,
+				"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+				6,
+				"USDC",
+				"USD Coin",
+			),
+			token1: new Token(
+				1,
+				"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+				18,
+				"WETH",
+				"Wrapped Ether",
+			),
+			amounts: {
+				amount0: "1000000",
+				amount1: "1000000000000000000",
+			},
+			tickLower: -100,
+			tickUpper: 100,
+			liquidity: BigInt("1000000000000000000"),
+			poolId: "0x1234567890123456789012345678901234567890",
+		};
+
+		(getPosition as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+			mockPosition,
+		);
+
+		const { result } = renderHook(
+			() =>
+				useGetPosition({
+					tokenId: "123",
+					chainId: 1,
+					queryOptions: {
+						enabled: true,
+						staleTime: 30000,
+					},
+				}),
+			{ wrapper },
+		);
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		expect(result.current.data).toEqual(mockPosition);
+	});
+});

--- a/src/test/utils/getPosition.test.ts
+++ b/src/test/utils/getPosition.test.ts
@@ -1,0 +1,151 @@
+import { getPosition } from "@/utils/getPosition";
+import { Token } from "@uniswap/sdk-core";
+import { type Address, zeroAddress } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the SDK instance
+vi.mock("@/core/uniDevKitV4Factory", () => ({
+	getInstance: () => mockGetInstance(),
+}));
+
+// Mock getTokens
+vi.mock("@/utils/getTokens", () => ({
+	getTokens: () => mockGetTokens(),
+}));
+
+const mockGetInstance = vi.fn();
+const mockGetTokens = vi.fn();
+
+describe("getPosition", () => {
+	// USDC and WETH on Mainnet
+	const mockTokens: [Address, Address] = [
+		"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+		"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
+	];
+	const mockTokenId = "123";
+	const mockChainId = 1;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	it("should throw error if SDK instance not found", async () => {
+		mockGetInstance.mockReturnValueOnce(undefined);
+		await expect(getPosition(mockTokenId, mockChainId)).rejects.toThrow(
+			"SDK not initialized",
+		);
+	});
+
+	it("should throw error if tokens not found", async () => {
+		const mockClient = {
+			multicall: vi.fn().mockResolvedValueOnce([
+				[
+					{
+						currency0: mockTokens[0],
+						currency1: mockTokens[1],
+						fee: 3000,
+						tickSpacing: 60,
+						hooks: zeroAddress,
+					},
+					"0x",
+				],
+				BigInt("1000000000000000000"),
+			]),
+		};
+
+		mockGetInstance.mockReturnValueOnce({
+			getClient: () => mockClient,
+			getContractAddress: vi.fn(() => "0xMockAddress"),
+		});
+		mockGetTokens.mockResolvedValueOnce(null);
+
+		await expect(getPosition(mockTokenId, mockChainId)).rejects.toThrow(
+			"Tokens not found",
+		);
+	});
+
+	it("should throw error if liquidity is 0", async () => {
+		const mockClient = {
+			multicall: vi.fn().mockResolvedValueOnce([
+				[
+					{
+						currency0: mockTokens[0],
+						currency1: mockTokens[1],
+						fee: 3000,
+						tickSpacing: 60,
+						hooks: zeroAddress,
+					},
+					"0x",
+				],
+				BigInt(0),
+			]),
+		};
+
+		mockGetInstance.mockReturnValueOnce({
+			getClient: () => mockClient,
+			getContractAddress: vi.fn(() => "0xMockAddress"),
+		});
+
+		mockGetTokens.mockResolvedValueOnce([
+			new Token(1, mockTokens[0], 6, "USDC", "USD Coin"),
+			new Token(1, mockTokens[1], 18, "WETH", "Wrapped Ether"),
+		]);
+
+		await expect(getPosition(mockTokenId, mockChainId)).rejects.toThrow(
+			"Liquidity is 0",
+		);
+	});
+
+	it("should return position data when position exists", async () => {
+		const mockTokenInstances = [
+			new Token(1, mockTokens[0], 6, "USDC", "USD Coin"),
+			new Token(1, mockTokens[1], 18, "WETH", "Wrapped Ether"),
+		];
+
+		// Compose a valid rawInfo: hasSubscriber=1, tickLower=0, tickUpper=60, poolId=0n
+		const hasSubscriber = 1n;
+		const tickLower = 0n;
+		const tickUpper = 60n;
+		const poolId = 0n;
+		const rawInfo =
+			hasSubscriber | (tickLower << 8n) | (tickUpper << 32n) | (poolId << 56n);
+		const mockPoolKey = {
+			currency0: mockTokens[0],
+			currency1: mockTokens[1],
+			fee: 3000,
+			tickSpacing: 60,
+			hooks: zeroAddress,
+		};
+
+		const mockClient = {
+			multicall: vi
+				.fn()
+				.mockResolvedValueOnce([
+					[mockPoolKey, rawInfo],
+					BigInt("1000000000000000000"),
+				])
+				.mockResolvedValueOnce([
+					[BigInt("79228162514264337593543950336"), 0],
+					BigInt("1000000000000000000"),
+				]),
+		};
+
+		mockGetInstance.mockReturnValueOnce({
+			getClient: () => mockClient,
+			getContractAddress: vi.fn(() => "0xMockAddress"),
+		});
+
+		mockGetTokens.mockResolvedValueOnce(mockTokenInstances);
+
+		const result = await getPosition(mockTokenId, mockChainId);
+
+		expect(result).toBeDefined();
+		expect(result?.token0).toEqual(mockTokenInstances[0]);
+		expect(result?.token1).toEqual(mockTokenInstances[1]);
+		expect(result?.liquidity).toBe(BigInt("1000000000000000000"));
+		expect(result?.amounts).toBeDefined();
+		expect(result?.tickLower).toBeDefined();
+		expect(result?.tickUpper).toBeDefined();
+		expect(result?.poolId).toBeDefined();
+	});
+});

--- a/src/types/hooks/index.ts
+++ b/src/types/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "@/types/hooks/useGetPool";
+export * from "@/types/hooks/useGetPosition";
 export * from "@/types/hooks/useGetQuote";

--- a/src/types/hooks/useGetPosition.ts
+++ b/src/types/hooks/useGetPosition.ts
@@ -1,0 +1,47 @@
+import type { UseQueryOptions } from "@tanstack/react-query";
+import type { Token } from "@uniswap/sdk-core";
+
+/**
+ * Result type for position data
+ */
+export interface PositionResult {
+	/** First token in the pair */
+	token0: Token;
+	/** Second token in the pair */
+	token1: Token;
+	/** Token amounts in the position */
+	amounts: {
+		/** Amount of token0 */
+		amount0: string;
+		/** Amount of token1 */
+		amount1: string;
+	};
+	/** Lower tick boundary of the position */
+	tickLower: number;
+	/** Upper tick boundary of the position */
+	tickUpper: number;
+	/** Total liquidity in the position */
+	liquidity: bigint;
+	/** Unique identifier for the pool */
+	poolId: `0x${string}`;
+}
+
+/**
+ * Configuration options for the useGetPosition hook
+ */
+export interface UseGetPositionOptions {
+	/** Token ID of the position */
+	tokenId?: string;
+	/** Chain ID to use */
+	chainId?: number;
+	/** React Query options */
+	queryOptions?: Omit<
+		UseQueryOptions<
+			PositionResult | undefined,
+			Error,
+			PositionResult | undefined,
+			unknown[]
+		>,
+		"queryKey"
+	>;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "@/types/core";
+export * from "@/types/hooks";
 export * from "@/types/utils";

--- a/src/types/utils/getQuote.ts
+++ b/src/types/utils/getQuote.ts
@@ -1,3 +1,4 @@
+import type { FeeTier } from "@/types/utils/getPool";
 import type { Address, Hex } from "viem";
 
 /**
@@ -10,14 +11,14 @@ export interface QuoteParams {
 	tokens: [Address, Address];
 
 	/**
-	 * The fee tier of the pool (e.g., 500, 3000, 10000).
+	 * The fee tier of the pool (e.g., FeeTier.MEDIUM).
 	 */
-	feeTier: number;
+	feeTier: FeeTier;
 
 	/**
-	 * The tick spacing for the pool. Must be a positive integer.
+	 * The tick spacing for the pool. If not provided, it will be derived from the fee tier.
 	 */
-	tickSpacing: number;
+	tickSpacing?: number;
 
 	/**
 	 * The amount of tokens being swapped, expressed as a bigint.

--- a/src/utils/getPosition.ts
+++ b/src/utils/getPosition.ts
@@ -1,0 +1,133 @@
+import { V4PositionManagerAbi } from "@/constants/abis/V4PositionMananger";
+import { V4StateViewAbi } from "@/constants/abis/V4StateView";
+import { getInstance } from "@/core/uniDevKitV4Factory";
+import { decodePositionInfo } from "@/helpers/positions";
+import { getTokens } from "@/utils/getTokens";
+import type { Token } from "@uniswap/sdk-core";
+import { Pool, Position as V4Position } from "@uniswap/v4-sdk";
+
+interface PositionResult {
+	token0: Token;
+	token1: Token;
+	amounts: {
+		amount0: string;
+		amount1: string;
+	};
+	tickLower: number;
+	tickUpper: number;
+	liquidity: bigint;
+	poolId: `0x${string}`;
+}
+
+export async function getPosition(
+	tokenId: string,
+	chainId?: number,
+): Promise<PositionResult | undefined> {
+	const sdk = getInstance(chainId);
+	if (!sdk) throw new Error("SDK not initialized");
+
+	const client = sdk.getClient();
+	const positionManager = sdk.getContractAddress("positionManager");
+	const stateView = sdk.getContractAddress("stateView");
+
+	const [poolAndPositionInfo, liquidity] = await client.multicall({
+		allowFailure: false,
+		contracts: [
+			{
+				address: positionManager,
+				abi: V4PositionManagerAbi,
+				functionName: "getPoolAndPositionInfo",
+				args: [BigInt(tokenId)],
+			},
+			{
+				address: positionManager,
+				abi: V4PositionManagerAbi,
+				functionName: "getPositionLiquidity",
+				args: [BigInt(tokenId)],
+			},
+		],
+	});
+
+	const [poolKey, rawInfo] = poolAndPositionInfo;
+
+	const { currency0, currency1, fee, tickSpacing, hooks } = poolKey;
+
+	console.log("poolKey", poolKey);
+	console.log("rawInfo", rawInfo);
+
+	if (liquidity === 0n) {
+		throw new Error("Liquidity is 0");
+	}
+
+	const tokens = await getTokens({
+		addresses: [currency0, currency1],
+		chainId,
+	});
+
+	if (!tokens) {
+		throw new Error("Tokens not found");
+	}
+
+	const [token0, token1] = tokens;
+
+	const poolId = Pool.getPoolId(
+		token0,
+		token1,
+		fee,
+		tickSpacing,
+		hooks,
+	) as `0x${string}`;
+
+	const [slot0, poolLiquidity] = await client.multicall({
+		allowFailure: false,
+		contracts: [
+			{
+				address: stateView,
+				abi: V4StateViewAbi,
+				functionName: "getSlot0",
+				args: [poolId],
+			},
+			{
+				address: stateView,
+				abi: V4StateViewAbi,
+				functionName: "getLiquidity",
+				args: [poolId],
+			},
+		],
+	});
+
+	const [sqrtPriceX96, tick] = slot0;
+
+	const pool = new Pool(
+		token0,
+		token1,
+		fee,
+		tickSpacing,
+		hooks,
+		sqrtPriceX96.toString(),
+		poolLiquidity.toString(),
+		tick,
+	);
+
+	const { tickLower, tickUpper } = decodePositionInfo(rawInfo);
+
+	const position = new V4Position({
+		pool,
+		liquidity: liquidity.toString(),
+		tickLower,
+		tickUpper,
+	});
+
+	return {
+		token0,
+		token1,
+		amounts: {
+			amount0: position.amount0.toSignificant(6),
+			amount1: position.amount1.toSignificant(6),
+		},
+		tickLower,
+		tickUpper,
+		liquidity,
+		poolId,
+	};
+}

--- a/src/utils/getQuote.ts
+++ b/src/utils/getQuote.ts
@@ -1,6 +1,7 @@
 import { V4QuoterAbi } from "@/constants/abis/V4Quoter";
 import { getInstance } from "@/core/uniDevKitV4Factory";
 import { sortTokens } from "@/helpers/tokens";
+import { FeeTier, TICK_SPACING_BY_FEE } from "@/types/utils/getPool";
 import type { QuoteParams, QuoteResponse } from "@/types/utils/getQuote";
 import { zeroAddress } from "viem";
 
@@ -35,12 +36,16 @@ export async function getQuote(
 			params.tokens[1],
 		);
 
+		// Use provided tick spacing or derive from fee tier
+		const fee = (params.feeTier ?? FeeTier.MEDIUM) as FeeTier;
+		const tickSpacing = params.tickSpacing ?? TICK_SPACING_BY_FEE[fee];
+
 		// Construct the poolKey
 		const poolKey = {
 			currency0,
 			currency1,
-			fee: params.feeTier,
-			tickSpacing: params.tickSpacing,
+			fee,
+			tickSpacing,
 			hooks: params.hooks || zeroAddress,
 		};
 


### PR DESCRIPTION
## 🚀 Add `getPosition` and `usePosition` to retrieve individual Uniswap V4 positions

### Summary

This PR adds two new utilities to simplify querying a single Uniswap V4 LP position:

- `getPosition(tokenId, chainId?)` – returns detailed on-chain data for a given position
- `usePosition(tokenId, options?)` – a React hook built on top of `react-query` for reactive usage

---

### ✅ Features

- Fetches position metadata via:
  - `getPoolAndPositionInfo`
  - `getPositionLiquidity`
  - `getSlot0`
  - `getLiquidity`
- Constructs `Token`, `Pool`, and `Position` objects using the official Uniswap V4 SDK
- Returns:
  - `token0` / `token1` metadata
  - Amounts of each token in the position
  - Fee tier, tick spacing, current tick
  - Pool liquidity and slot0 data
  - Pool ID

---

### 🧠 Why

Before:
- Manually call 3–4 contracts
- Decode ABI bytes manually
- Build `Pool` and `Position` instances yourself

After:
```ts
const position = await getPosition(tokenId)
// Or with the hook:
const { data, isLoading } = usePosition(tokenId)
```

