### PR TITLE
Feat/remove liquidity

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Full API documentation with TypeDoc: [https://bootnodedev.github.io/uni-dev-kit]
     - [`buildSwapCallData`](#buildswapcalldata)
     - [`buildAddLiquidityCallData`](#buildaddliquiditycalldata)
     - [`preparePermit2BatchCallData`](#preparepermit2batchcalldata)
+    - [`buildRemoveLiquidityCallData`](#buildremoveliquiditycalldata)
       - [Basis Points Reference](#basis-points-reference)
   - [Useful Links](#useful-links)
   - [Development](#development)
@@ -211,6 +212,22 @@ const permitData = await uniDevKit.preparePermit2BatchCallData({
   tokens: [tokenA.address, tokenB.address],
   spender: uniDevKit.getContractAddress('positionManager'),
   owner: userAddress
+});
+```
+
+### `buildRemoveLiquidityCallData`
+Build calldata to remove liquidity from a pool.
+```ts
+const { calldata, value } = await uniDevKit.buildRemoveLiquidityCallData({
+  liquidityPercentage: 10_000, // 100%
+  tokenId: '123',
+  slippageTolerance: 50, // 0.5%
+});
+
+const tx = await sendTransaction({
+  to: uniDevKit.getContractAddress('positionManager'),
+  data: calldata,
+  value
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-dev-kit",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A modern TypeScript library for integrating Uniswap into your dapp.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_DEADLINE = 60 * 10 // 10 minutes
+export const DEFAULT_SLIPPAGE_TOLERANCE = 50

--- a/src/core/uniDevKitV4.ts
+++ b/src/core/uniDevKitV4.ts
@@ -17,6 +17,10 @@ import type {
   PreparePermit2DataResult,
 } from '@/types/utils/permit2'
 import { buildAddLiquidityCallData } from '@/utils/buildAddLiquidityCallData'
+import {
+  type BuildRemoveLiquidityCallDataParams,
+  buildRemoveLiquidityCallData,
+} from '@/utils/buildRemoveLiquidityCallData'
 import { buildSwapCallData } from '@/utils/buildSwapCallData'
 import { getPool } from '@/utils/getPool'
 import { getPoolKeyFromPoolId } from '@/utils/getPoolKeyFromPoolId'
@@ -233,5 +237,15 @@ export class UniDevKitV4 {
    */
   async preparePermit2Data(params: PreparePermit2DataParams): Promise<PreparePermit2DataResult> {
     return preparePermit2Data(params, this.instance)
+  }
+
+  /**
+   * Builds a remove liquidity call data for a given remove liquidity parameters.
+   * @param params @type {BuildRemoveLiquidityCallDataParams}
+   * @returns Promise resolving to remove liquidity call data including calldata and value
+   * @throws Error if SDK instance is not found or if remove liquidity call data is invalid
+   */
+  async buildRemoveLiquidityCallData(params: BuildRemoveLiquidityCallDataParams) {
+    return buildRemoveLiquidityCallData(params, this.instance)
   }
 }

--- a/src/test/utils/buildRemoveLiquidityCallData.test.ts
+++ b/src/test/utils/buildRemoveLiquidityCallData.test.ts
@@ -1,0 +1,124 @@
+import { createMockSdkInstance } from '@/test/helpers/sdkInstance'
+import { getDefaultDeadline } from '@/utils/getDefaultDeadline'
+import { getPosition } from '@/utils/getPosition'
+import { Token } from '@uniswap/sdk-core'
+import { Pool, Position, V4PositionManager } from '@uniswap/v4-sdk'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const instance = createMockSdkInstance()
+
+vi.mock('@/utils/getPosition', () => ({
+  getPosition: vi.fn(),
+}))
+
+const token0 = new Token(1, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', 6, 'USDC', 'USD Coin')
+const token1 = new Token(
+  1,
+  '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+  18,
+  'WETH',
+  'Wrapped Ether',
+)
+const pool = new Pool(
+  token0,
+  token1,
+  3000,
+  60,
+  '0x1111111111111111111111111111111111111111',
+  '79228162514264337593543950336',
+  '1000000', // liquidity as string
+  0,
+)
+const position = new Position({ pool, liquidity: '1000000', tickLower: -60, tickUpper: 60 }) // liquidity as string
+
+const mockPosition = {
+  position,
+  pool,
+  token0,
+  token1,
+  poolId: '0x1111111111111111111111111111111111111111' as `0x${string}`,
+  tokenId: '1',
+}
+
+describe('buildRemoveLiquidityCallData', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should build calldata for removing 100% liquidity', async () => {
+    vi.mock('@/utils/getDefaultDeadline', () => ({
+      getDefaultDeadline: vi.fn().mockResolvedValue('1234567890'),
+    }))
+    vi.mocked(getPosition).mockReturnValueOnce(Promise.resolve(mockPosition))
+    vi.spyOn(V4PositionManager, 'removeCallParameters').mockReturnValueOnce({
+      calldata: '0x123',
+      value: '0',
+    })
+    const { buildRemoveLiquidityCallData } = await import('@/utils/buildRemoveLiquidityCallData')
+    const result = await buildRemoveLiquidityCallData(
+      {
+        liquidityPercentage: 10_000,
+        tokenId: '1',
+        deadline: '123',
+      },
+      instance,
+    )
+    expect(result.calldata).toBe('0x123')
+    expect(result.value).toBe('0')
+  })
+
+  it('should use custom slippageTolerance', async () => {
+    vi.mock('@/utils/getDefaultDeadline', () => ({
+      getDefaultDeadline: vi.fn().mockResolvedValue('1234567890'),
+    }))
+    vi.mocked(getPosition).mockReturnValueOnce(Promise.resolve(mockPosition))
+    const spy = vi.spyOn(V4PositionManager, 'removeCallParameters').mockReturnValueOnce({
+      calldata: '0xabc',
+      value: '1',
+    })
+    const { buildRemoveLiquidityCallData } = await import('@/utils/buildRemoveLiquidityCallData')
+    await buildRemoveLiquidityCallData(
+      {
+        liquidityPercentage: 5000,
+        tokenId: '1',
+        slippageTolerance: 123,
+        deadline: '123',
+      },
+      instance,
+    )
+    expect(spy).toHaveBeenCalledWith(
+      mockPosition.position,
+      expect.objectContaining({ slippageTolerance: expect.any(Object) }),
+    )
+  })
+
+  it('should throw if position not found', async () => {
+    vi.mock('@/utils/getDefaultDeadline', () => ({
+      getDefaultDeadline: vi.fn().mockResolvedValue('1234567890'),
+    }))
+    vi.mocked(getPosition).mockReturnValueOnce(
+      Promise.resolve(undefined as unknown as ReturnType<typeof getPosition>),
+    )
+    const { buildRemoveLiquidityCallData } = await import('@/utils/buildRemoveLiquidityCallData')
+    await expect(
+      buildRemoveLiquidityCallData({ liquidityPercentage: 10_000, tokenId: '404' }, instance),
+    ).rejects.toThrow('Position not found')
+  })
+
+  it('should throw if V4PositionManager throws', async () => {
+    vi.mock('@/utils/getDefaultDeadline', () => ({
+      getDefaultDeadline: vi.fn().mockResolvedValue('1234567890'),
+    }))
+    vi.mocked(getPosition).mockReturnValueOnce(Promise.resolve(mockPosition))
+    vi.spyOn(V4PositionManager, 'removeCallParameters').mockImplementationOnce(() => {
+      throw new Error('fail')
+    })
+    const { buildRemoveLiquidityCallData } = await import('@/utils/buildRemoveLiquidityCallData')
+    await expect(
+      buildRemoveLiquidityCallData(
+        { liquidityPercentage: 10_000, tokenId: '1', deadline: '123' },
+        instance,
+      ),
+    ).rejects.toThrow('fail')
+  })
+})

--- a/src/test/utils/buildRemoveLiquidityCallData.test.ts
+++ b/src/test/utils/buildRemoveLiquidityCallData.test.ts
@@ -1,5 +1,4 @@
 import { createMockSdkInstance } from '@/test/helpers/sdkInstance'
-import { getDefaultDeadline } from '@/utils/getDefaultDeadline'
 import { getPosition } from '@/utils/getPosition'
 import { Token } from '@uniswap/sdk-core'
 import { Pool, Position, V4PositionManager } from '@uniswap/v4-sdk'

--- a/src/utils/buildAddLiquidityCallData.ts
+++ b/src/utils/buildAddLiquidityCallData.ts
@@ -1,14 +1,13 @@
+import { DEFAULT_SLIPPAGE_TOLERANCE } from '@/constants/common'
+import { percentFromBips } from '@/helpers/percent'
 import type { UniDevKitV4Instance } from '@/types'
 import type {
   BuildAddLiquidityCallDataResult,
   BuildAddLiquidityParams,
 } from '@/types/utils/buildAddLiquidityCallData'
-import { Percent } from '@uniswap/sdk-core'
+import { getDefaultDeadline } from '@/utils/getDefaultDeadline'
 import { TickMath, encodeSqrtRatioX96, nearestUsableTick } from '@uniswap/v3-sdk'
 import { Position, V4PositionManager } from '@uniswap/v4-sdk'
-
-const DEFAULT_DEADLINE = 1800n // 30 minutes
-const DEFAULT_SLIPPAGE_TOLERANCE = 50
 
 /**
  * Builds the calldata and native value required to add liquidity to a Uniswap V4 pool.
@@ -80,14 +79,10 @@ export async function buildAddLiquidityCallData(
     permit2BatchSignature,
   } = params
 
-  console.log('params', params)
-
   try {
-    const deadline =
-      deadlineParam ??
-      (await instance.client.getBlock().then((b) => b.timestamp + DEFAULT_DEADLINE)).toString()
+    const deadline = deadlineParam ?? (await getDefaultDeadline(instance)).toString()
 
-    const slippagePercent = new Percent(slippageTolerance, 10_000)
+    const slippagePercent = percentFromBips(slippageTolerance)
     const createPool = pool.liquidity.toString() === '0'
 
     const tickLower = tickLowerParam ?? nearestUsableTick(TickMath.MIN_TICK, pool.tickSpacing)

--- a/src/utils/getDefaultDeadline.ts
+++ b/src/utils/getDefaultDeadline.ts
@@ -1,0 +1,9 @@
+import { DEFAULT_DEADLINE } from '@/constants/common'
+import type { UniDevKitV4Instance } from '@/types'
+
+export async function getDefaultDeadline(
+  instance: UniDevKitV4Instance,
+  timeFromNow: number = DEFAULT_DEADLINE,
+): Promise<bigint> {
+  return (await instance.client.getBlock()).timestamp + BigInt(timeFromNow)
+}


### PR DESCRIPTION
# Add Remove Liquidity Support (`buildRemoveLiquidityCallData`)

## Overview
This PR adds support for building calldata to remove liquidity from Uniswap V4 positions. Developers can now easily generate calldata and value for partial or full liquidity removal, with slippage and deadline controls, ready to be sent to the PositionManager contract.

## Changes
- Added `buildRemoveLiquidityCallData` utility for preparing calldata to remove liquidity from a position.
- Added comprehensive unit tests for `buildRemoveLiquidityCallData`.
- Updated the README with usage instructions and parameter documentation for removing liquidity.

## Technical Details
- `buildRemoveLiquidityCallData`:
  - Accepts `liquidityPercentage` (in BPS), `tokenId`, optional `slippageTolerance`, and optional `deadline`.
  - Fetches position data and builds calldata using the Uniswap V4 SDK.
  - Handles default and custom deadlines.
  - Throws clear errors if the position is not found or if the SDK fails.
- README:
  - Documents the new function with a usage example.
  - Clarifies BPS usage for all percentage-based parameters.

## Testing
Added test suite:  
- `buildRemoveLiquidityCallData.test.ts` covering:
  - 100% liquidity removal
  - Custom slippage tolerance
  - Error when position is not found
  - Error propagation from the Uniswap SDK

## Usage Example
```typescript
const { calldata, value } = await uniDevKit.buildRemoveLiquidityCallData({
  liquidityPercentage: 10_000, // 100%
  tokenId: '123',
  slippageTolerance: 50, // 0.5%
  deadline: '1700000000'
});

const tx = await sendTransaction({
  to: uniDevKit.getContractAddress('positionManager'),
  data: calldata,
  value
});
```